### PR TITLE
serverでCloudflare pagesでホスティングされるclientのオリジンを許可する

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "scripts": {
     "dev": "wrangler dev --env dev",
-    "deploy": "wrangler deploy --minify",
+    "deploy": "wrangler deploy --minify --env staging",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "test": "vitest run",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,8 +4,7 @@ import { cors } from "hono/cors";
 
 type Bindings = {
   CLIENT_URLS: string[];
-  LOCAL_CLIENT_URL: string;
-  CLOUDFLARE_CLIENT_DOMAIN: string;
+  CF_CLIENT_DOMAIN: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -13,9 +12,12 @@ const app = new Hono<{ Bindings: Bindings }>();
 const router = app
   .use("*", async (c, next) => {
     const corsMiddlewareHandler = cors({
-      origin: (origin, c) => {
-        return origin.endsWith(c.env.CLOUDFLARE_CLIENT_DOMAIN) ? origin : c.env.LOCAL_CLIENT_URL;
-      },
+      origin:
+        c.env.CF_CLIENT_DOMAIN !== ""
+          ? (origin) => {
+              return origin.endsWith(c.env.CF_CLIENT_DOMAIN) ? origin : null;
+            }
+          : c.env.CLIENT_URLS,
     });
     return corsMiddlewareHandler(c, next);
   })

--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -7,13 +7,21 @@
   //   "nodejs_compat"
   // ],
   "env": {
+    "staging": {
+      "vars": {
+        "CF_CLIENT_DOMAIN": "bonblogv2.pages.dev",
+        "CLIENT_URLS": []
+      }
+    },
     "dev": {
       "vars": {
+        "CF_CLIENT_DOMAIN": "",
         "CLIENT_URLS": ["http://localhost:4173", "http://localhost:5173"]
       }
     },
     "test": {
       "vars": {
+        "CF_CLIENT_DOMAIN": "",
         "CLIENT_URLS": ["http://example.com"]
       }
     }


### PR DESCRIPTION
## チケット
- #28 

## 概要
- Cloudflare Workersホスティング先の`apps/server`でアクセス元の末尾のドメインがCloudflare Pagesでホスティングされる`apps/client`のオリジンのものであるとき、通信を許可するように変更

## 変更内容
- 許可するアクセス元の末尾のドメインを環境変数`CF_CLIENT_DOMAIN`から設定できるように変更
- deploy時の`wrangler`の`env`を`staging`に設定

## 確認内容
- ローカルで`apps/server`を動かした状態で下記の通信が成功することを確認
  - `apps/client`を`pnpm run dev`, build後`pnpm run preview`で動かした時に通信を含めた動作が、正常に動作する。

- Cloudflare Workersでホスティングされる`server`に対して下記の通信が成功することを確認
  - Cloudflare Pagesでホスティングされる`apps/client`から通信を含めた動作が、正常に動作する。

## 備考
