### PR TITLE
[`server`のアーキテクチャ設計]middlewareの整理

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,27 +1,12 @@
+import corsMiddleware from "@server/middlewares/cors";
 import blogs from "@server/routes/blogs";
 import { Hono } from "hono";
 import { type InferResponseType, hc } from "hono/client";
-import { cors } from "hono/cors";
 
-type Bindings = {
-  CLIENT_URLS: string[];
-  CF_CLIENT_DOMAIN: string;
-};
-
-const app = new Hono<{ Bindings: Bindings }>();
+const app = new Hono();
 
 const router = app
-  .use("*", async (c, next) => {
-    const corsMiddlewareHandler = cors({
-      origin:
-        c.env.CF_CLIENT_DOMAIN !== ""
-          ? (origin) => {
-              return origin.endsWith(c.env.CF_CLIENT_DOMAIN) ? origin : null;
-            }
-          : c.env.CLIENT_URLS,
-    });
-    return corsMiddlewareHandler(c, next);
-  })
+  .use("*", corsMiddleware)
   .get("/", (c) => {
     return c.json({ message: "Hello Hono!" });
   })

--- a/apps/server/src/middlewares/cors.ts
+++ b/apps/server/src/middlewares/cors.ts
@@ -1,0 +1,22 @@
+import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
+
+type Bindings = {
+  Bindings: {
+    CLIENT_URLS: string[];
+    CF_CLIENT_DOMAIN: string;
+  };
+};
+
+const corsMiddleware = createMiddleware<Bindings>(async (c, next) => {
+  return cors({
+    origin:
+      c.env.CF_CLIENT_DOMAIN !== ""
+        ? (origin) => {
+            return origin.endsWith(c.env.CF_CLIENT_DOMAIN) ? origin : null;
+          }
+        : c.env.CLIENT_URLS,
+  })(c, next);
+});
+
+export default corsMiddleware;

--- a/apps/server/src/routes/blogs.ts
+++ b/apps/server/src/routes/blogs.ts
@@ -5,7 +5,8 @@ import { markdownFormatter } from "@server/utils/markdown";
 import { Hono } from "hono";
 
 const blogs = new Hono()
-  .get("/", notionMiddleware, async (c) => {
+  .use("*", notionMiddleware)
+  .get("/", async (c) => {
     try {
       c.set("notionDatabaseId", c.env.NOTION_DATABASE_ID);
       const res = await queryDatabase(c);
@@ -34,7 +35,7 @@ const blogs = new Hono()
       return c.json({ message: "Failed to fetch database" }, 500);
     }
   })
-  .get("/:id", notionMiddleware, async (c) => {
+  .get("/:id", async (c) => {
     try {
       c.set("notionPageId", c.req.param("id"));
       const [page, mdContent] = await Promise.all([


### PR DESCRIPTION
## チケット
- #91 

## 概要
- cors設定用のmiddlewareを別ファイルに切り出し

## 変更内容

## 確認内容
- local（`dev`, `build`→`start`）とデプロイ先で、`cors`に引っ掛からずアクセスできることを確認

## 備考
